### PR TITLE
No warning for arrays with zeros in logscale

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -514,11 +514,13 @@ class PlotDataItem(GraphicsObject):
                 # Ignore the first bin for fft data if we have a logx scale
                 if self.opts['logMode'][0]:
                     x=x[1:]
-                    y=y[1:]                
-            if self.opts['logMode'][0]:
-                x = np.log10(x)
-            if self.opts['logMode'][1]:
-                y = np.log10(y)
+                    y=y[1:]
+                    
+            with np.errstate(divide='ignore'):
+                if self.opts['logMode'][0]:
+                    x = np.log10(x)
+                if self.opts['logMode'][1]:
+                    y = np.log10(y)
                     
             ds = self.opts['downsample']
             if not isinstance(ds, int):


### PR DESCRIPTION
NumPy evaluates log10(0) to -inf, so there is no reason to show the user a RuntimeWarning. Before, if visualizing data arrays containing zeros in logscale, a RuntimeWarning was shown. Additionally: Removed some invisible whitspace.