### PR TITLE
Removed system_site_packages from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ sudo: false
 notifications:
   email: false
 
-virtualenv:
-    system_site_packages: true
-
-
 env:
     # Enable python 2 and python 3 builds
     # Note that the 2.6 build doesn't get flake8, and runs old versions of


### PR DESCRIPTION
system_site_packages are opposed to the used conda installation. They are both unnecessary and lead to Travis build errors.